### PR TITLE
Minor tweaks to grid interpolator

### DIFF
--- a/requirements_minimal.txt
+++ b/requirements_minimal.txt
@@ -7,4 +7,3 @@ tqdm
 tensorflow>=2.2.0
 tensorflow_probability>=0.8.0
 iminuit
-sklearn

--- a/tests/test_mu.py
+++ b/tests/test_mu.py
@@ -98,12 +98,14 @@ def test_constant_mu():
 
 
 def test_grid_interpolation():
-    ll = fd.LogLikelihood(**ll_options, mu_estimators=fd.GridInterpolatedMu)
+    ll = fd.LogLikelihood(
+        **ll_options,
+        mu_estimators=fd.GridInterpolatedMu)
 
     # Interpolate both variables
     mu_est = -ll(x=0.5, y=0.3)
 
-    points = ([-1, 0, 1], [-1, 0, 1])
+    points = ([-1, 1], [-1, 1])
     mu_grid = mu_func(*np.meshgrid(*points, indexing='ij'))
 
     assert np.isclose(mu_est, interpn(points, mu_grid, np.array([0.5, 0.3])))


### PR DESCRIPTION
See https://github.com/FlamTeam/flamedisx/pull/242.
  * Use two anchors by default to avoid cusps / lines with dicontinuous derivative in the middle of the likelihood, for consistency with the default interpolator, and to reduce default precomputation time from 3^n_params to 2^n_params.
  * Do not add sklearn dependency, use builtin itertools.product directly instead.
  * Use order of parameters the mu estimator was built with (reflecting the likelihood parameter ordering), instead of lexical key ordering
  * Populate grid_dict, grid_shape etc. in a single loop.